### PR TITLE
CreateRepository: Return an error if 'name' field contains a slash character

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Creating new repositories can be done through the [Swagger UI](https://d.ims.io/
 
 Each image must have both an `owner` and a `name`.
 An `owner` is typically the name of the team you are own. 
+A `name` cannot contain any slash characters (`/`).
 Images are referenced by `d.ims.io/<owner>/<name>`. 
 
 For example, if team `carbon` created a `redis` image, images could be pushed via:

--- a/controllers/repository_test.go
+++ b/controllers/repository_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -30,6 +31,20 @@ func TestCreateRepository(t *testing.T) {
 
 	c := generateContext(t, models.CreateRepositoryRequest{Name: "test"}, map[string]string{"owner": "user"})
 	if _, err := controller.CreateRepository(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCreateRepositoryFailsWithSlashes(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockECR := mock.NewMockECRAPI(ctrl)
+	controller := NewRepositoryController(mockECR)
+
+	c := generateContext(t, models.CreateRepositoryRequest{Name: "slash/test"}, map[string]string{"owner": "user"})
+	_, err := controller.CreateRepository(c)
+	if !strings.ContainsAny(err.Error(), "cannot contain '/' characters") {
 		t.Fatal(err)
 	}
 }

--- a/models/create_repository_request.go
+++ b/models/create_repository_request.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/zpatrick/go-plugin-swagger"
 )
@@ -22,6 +23,10 @@ func (r CreateRepositoryRequest) Definition() swagger.Definition {
 func (r CreateRepositoryRequest) Validate() error {
 	if r.Name == "" {
 		return fmt.Errorf("Field 'name' is required")
+	}
+
+	if strings.ContainsAny(r.Name, "/") {
+		return fmt.Errorf("Field 'name' cannot contain '/' characters")
 	}
 
 	return nil


### PR DESCRIPTION
# What does this pull request do?
Fixes a bug where a user could create a repository with a name that contained one or more slashes. This registry frontend does not support lookup of repositories that contain slashes, and allowing a user to create such a repository resulted in a repository that could not be accessed.

# How should this be tested?
Confirm that attempting to create a repository whose name contains a slash character fails with an appropriate error message.

# Checklist
- [x] Unit tests
- ~Smoke tests (if applicable)~
- ~System tests (if applicable)~
- [x] Documentation (if applicable)

# What does this pull request resolve?
Closes #43 
