### PR TITLE
Backoff & Retry for Auth0 429 Responses; Throttling

### DIFF
--- a/auth/auth0_manager.go
+++ b/auth/auth0_manager.go
@@ -12,14 +12,11 @@ import (
 var timeMultiplier = 1
 
 type Auth0Manager struct {
-	clientID           string
-	connection         string
-	client             *rclient.RestClient
-	cache              *cache.Cache
-	throttle           <-chan time.Time
-	throttleMin        int
-	throttleMultiplier int
-	lastThrottled      time.Time
+	clientID   string
+	connection string
+	client     *rclient.RestClient
+	cache      *cache.Cache
+	throttle   <-chan time.Time
 }
 
 type oauthReq struct {
@@ -41,32 +38,17 @@ const (
 	validAuthExpiry = 1 * time.Hour
 )
 
-func NewAuth0Manager(domain, clientID, connection string, throttleMin int) *Auth0Manager {
+func NewAuth0Manager(domain, clientID, connection string, rateLimit time.Duration) *Auth0Manager {
 	return &Auth0Manager{
-		clientID:           clientID,
-		connection:         connection,
-		client:             rclient.NewRestClient(domain),
-		cache:              cache.New(),
-		throttle:           time.Tick(time.Millisecond * time.Duration(throttleMin)),
-		throttleMin:        throttleMin,
-		throttleMultiplier: throttleMin,
-		lastThrottled:      time.Now(),
+		clientID:   clientID,
+		connection: connection,
+		client:     rclient.NewRestClient(domain),
+		cache:      cache.New(),
+		throttle:   time.Tick(rateLimit),
 	}
 }
 
 func (a *Auth0Manager) Authenticate(username, password string) (bool, error) {
-	if a.throttleMultiplier > a.throttleMin && time.Since(a.lastThrottled) > 1*time.Minute {
-		a.throttleMultiplier = a.throttleMultiplier / 2
-		if a.throttleMultiplier < a.throttleMin {
-			a.throttleMultiplier = a.throttleMin
-		}
-
-		log.Printf("[INFO] 1 min since last throttle update, decreasing throttle to %v", time.Millisecond*time.Duration(a.throttleMultiplier))
-
-		a.throttle = time.Tick(time.Millisecond / time.Duration(a.throttleMultiplier))
-		a.lastThrottled = time.Now()
-	}
-
 	key := fmt.Sprintf("%s:%s", username, password)
 	var cachedStatus *authStatus
 	if result, exists := a.cache.Getf(key); exists {
@@ -79,12 +61,32 @@ func (a *Auth0Manager) Authenticate(username, password string) (bool, error) {
 		return true, nil
 	}
 
-	// throttle to deal with rate limiting
-	<-a.throttle
-
 	// will only sleep if cachedStatus already exists with a penalty
 	time.Sleep(cachedStatus.penalty * time.Duration(timeMultiplier))
 
+	isAuthenticated, err := a.authenticate(username, password)
+	if err != nil {
+		return false, err
+	}
+
+	if !isAuthenticated {
+		cachedStatus.penalty += time.Second
+		if cachedStatus.penalty > maxPenalty {
+			cachedStatus.penalty = maxPenalty
+		}
+
+		a.cache.Add(key, cachedStatus)
+		return false, nil
+	}
+
+	cachedStatus.isValid = true
+	cachedStatus.penalty = 0 * time.Second
+	a.cache.Addf(key, cachedStatus, validAuthExpiry)
+
+	return true, nil
+}
+
+func (a *Auth0Manager) authenticate(username, password string) (bool, error) {
 	req := oauthReq{
 		ClientID:   a.clientID,
 		Connection: a.connection,
@@ -94,35 +96,30 @@ func (a *Auth0Manager) Authenticate(username, password string) (bool, error) {
 		Scope:      "openid",
 	}
 
-	if err := a.client.Post("/oauth/ro", req, nil); err != nil {
-		if err, ok := err.(*rclient.ResponseError); ok && (err.Response.StatusCode == 401 || err.Response.StatusCode == 429) {
-			cachedStatus.penalty += time.Second
-			if cachedStatus.penalty > maxPenalty {
-				cachedStatus.penalty = maxPenalty
-			}
+	for backoff := time.Duration(0); true; backoff += time.Millisecond * 500 {
+		time.Sleep(backoff * time.Duration(timeMultiplier))
+		<-a.throttle
 
-			if err.Response.StatusCode == 429 {
-				if a.throttleMultiplier > 0 {
-					a.throttleMultiplier = a.throttleMultiplier * 2
-				} else {
-					a.throttleMultiplier = 1
+		if err := a.client.Post("/oauth/ro", req, nil); err != nil {
+			if err, ok := err.(*rclient.ResponseError); ok {
+				switch err.Response.StatusCode {
+				case 401:
+					log.Printf("[DEBUG] User '%s' sent invalid Auth0 credentials.", username)
+					return false, nil
+				case 429:
+					log.Printf("[DEBUG] Auth0 returned 429 response for user '%s'; retrying.", username)
+					continue
+				default:
+					return false, err
 				}
-
-				log.Printf("[INFO] Too many requests, increasing throttle to %v", time.Millisecond*time.Duration(a.throttleMultiplier))
-
-				a.throttle = time.Tick(time.Millisecond * time.Duration(a.throttleMultiplier))
-				a.lastThrottled = time.Now()
 			}
 
-			a.cache.Add(key, cachedStatus)
-			return false, nil
+			return false, err
 		}
 
-		return false, err
+		log.Printf("User '%s' sent valid Auth0 credentials.", username)
+		break
 	}
 
-	cachedStatus.isValid = true
-	cachedStatus.penalty = 0 * time.Second
-	a.cache.Addf(key, cachedStatus, validAuthExpiry)
 	return true, nil
 }

--- a/auth/auth0_manager.go
+++ b/auth/auth0_manager.go
@@ -96,7 +96,7 @@ func (a *Auth0Manager) authenticate(username, password string) (bool, error) {
 		Scope:      "openid",
 	}
 
-	for backoff := time.Duration(0); true; backoff += time.Millisecond * 500 {
+	for backoff := time.Duration(0); true; backoff += (time.Millisecond * 500) {
 		time.Sleep(backoff * time.Duration(timeMultiplier))
 		<-a.throttle
 
@@ -117,7 +117,7 @@ func (a *Auth0Manager) authenticate(username, password string) (bool, error) {
 			return false, err
 		}
 
-		log.Printf("User '%s' sent valid Auth0 credentials.", username)
+		log.Printf("[DEBUG] User '%s' sent valid Auth0 credentials.", username)
 		break
 	}
 

--- a/auth/auth0_manager_test.go
+++ b/auth/auth0_manager_test.go
@@ -110,3 +110,25 @@ func TestAuth0ManagerAuthenticate_NotValidCredsAreChecked(t *testing.T) {
 
 	assert.Equal(t, count, 2)
 }
+
+func TestAuth0ManagerAuthenticate_RetriesOn429(t *testing.T) {
+	count := 0
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if count < 2 {
+			MarshalAndWrite(t, w, nil, 429)
+		} else {
+			MarshalAndWrite(t, w, nil, 200)
+		}
+
+		count++
+	}
+
+	auth0Manager, server := newAuth0ManagerAndServer(handler)
+	defer server.Close()
+
+	_, err := auth0Manager.Authenticate("", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -7,13 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 type Handler func(w http.ResponseWriter, r *http.Request)
 
 func newAuth0ManagerAndServer(handler Handler) (*Auth0Manager, *httptest.Server) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
-	auth0Manager := NewAuth0Manager(server.URL, "", "", 500)
+	auth0Manager := NewAuth0Manager(server.URL, "", "", 500*time.Millisecond)
 
 	return auth0Manager, server
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -14,7 +14,7 @@ type Handler func(w http.ResponseWriter, r *http.Request)
 
 func newAuth0ManagerAndServer(handler Handler) (*Auth0Manager, *httptest.Server) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
-	auth0Manager := NewAuth0Manager(server.URL, "", "", 500*time.Millisecond)
+	auth0Manager := NewAuth0Manager(server.URL, "", "", time.Second/2)
 
 	return auth0Manager, server
 }

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -13,7 +13,7 @@ type Handler func(w http.ResponseWriter, r *http.Request)
 
 func newAuth0ManagerAndServer(handler Handler) (*Auth0Manager, *httptest.Server) {
 	server := httptest.NewServer(http.HandlerFunc(handler))
-	auth0Manager := NewAuth0Manager(server.URL, "", "")
+	auth0Manager := NewAuth0Manager(server.URL, "", "", 500)
 
 	return auth0Manager, server
 }

--- a/main.go
+++ b/main.go
@@ -99,7 +99,8 @@ func main() {
 		tokenManager := auth.NewDynamoTokenManager(c.String("dynamo-table"), dynamodb)
 		auth0Manager := auth.NewAuth0Manager(c.String("auth0-domain"),
 			c.String("auth0-client-id"),
-			c.String("auth0-connection"))
+			c.String("auth0-connection"),
+			500)
 
 		authenticator := auth.NewCompositeAuthenticator(tokenManager, auth0Manager)
 		proxy := proxy.NewECRProxy(c.String("registry-endpoint"))

--- a/main.go
+++ b/main.go
@@ -101,7 +101,7 @@ func main() {
 		auth0Manager := auth.NewAuth0Manager(c.String("auth0-domain"),
 			c.String("auth0-client-id"),
 			c.String("auth0-connection"),
-			time.Millisecond*500)
+			time.Second/2)
 
 		authenticator := auth.NewCompositeAuthenticator(tokenManager, auth0Manager)
 		proxy := proxy.NewECRProxy(c.String("registry-endpoint"))

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/defaults"
@@ -100,7 +101,7 @@ func main() {
 		auth0Manager := auth.NewAuth0Manager(c.String("auth0-domain"),
 			c.String("auth0-client-id"),
 			c.String("auth0-connection"),
-			500)
+			time.Millisecond*500)
 
 		authenticator := auth.NewCompositeAuthenticator(tokenManager, auth0Manager)
 		proxy := proxy.NewECRProxy(c.String("registry-endpoint"))

--- a/vendor/github.com/zpatrick/go-bytesize/LICENSE
+++ b/vendor/github.com/zpatrick/go-bytesize/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2017, Zack Patrick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/zpatrick/go-bytesize/README.md
+++ b/vendor/github.com/zpatrick/go-bytesize/README.md
@@ -1,0 +1,41 @@
+# Go Bytesize
+
+[![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/zpatrick/go-bytesize/blob/master/LICENSE)
+[![Go Report Card](https://goreportcard.com/badge/github.com/zpatrick/go-bytesize)](https://goreportcard.com/report/github.com/zpatrick/go-bytesize)
+[![Go Doc](https://godoc.org/github.com/zpatrick/go-bytesize?status.svg)](https://godoc.org/github.com/zpatrick/go-bytesize)
+
+
+## Overview
+Go Bytesize is a utility package for working with common multiples of bytes in Go, such as: Bytes (B), Kilobytes (KB), Megabytes (MB), Gigabytes (GB), Terabytes (TB), Petabytes (PB), Exabytes (EB), Kibibytes (Kib), Mebibytes (MiB), Gibibytes (GiB), Tebibytes (TiB), Pebibytes (PiB), and Exbibytes (EiB).  
+
+## Example
+```
+package main
+
+import (
+        "fmt"
+        "github.com/zpatrick/go-bytesize"
+)
+
+func main() {
+        b := bytesize.Bytesize(10000)
+        fmt.Printf("%g bytes is: %g KB and %g MB\n", b, b.Kilobytes(), b.Megabytes())
+
+        b = bytesize.TB * 2
+        fmt.Printf("2 Terabytes is %g Gibibytes\n", b.Gibibytes())
+
+        b = bytesize.Bytesize(1000000)
+        fmt.Printf("%g bytes is %s\n", b, b.Format("mb"))
+}
+```
+
+Output:
+```
+10000 bytes is: 10 KB and 0.01 MB
+2 Terabytes is 1862.645149230957 Gibibytes
+1e+06 bytes is 1MB
+```
+
+## License
+This work is published under the MIT license.
+Please see the `LICENSE` file for details.

--- a/vendor/github.com/zpatrick/go-bytesize/bytesize.go
+++ b/vendor/github.com/zpatrick/go-bytesize/bytesize.go
@@ -1,0 +1,143 @@
+package bytesize
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Bytesize represents a single byte as a float64
+type Bytesize float64
+
+// bytes sizes generally used for computer storage and memory
+const (
+	B  Bytesize = 1
+	KB Bytesize = 1000 * B
+	MB Bytesize = 1000 * KB
+	GB Bytesize = 1000 * MB
+	TB Bytesize = 1000 * GB
+	PB Bytesize = 1000 * TB
+	EB Bytesize = 1000 * PB
+
+	KiB Bytesize = 1024 * B
+	MiB Bytesize = 1024 * KiB
+	GiB Bytesize = 1024 * MiB
+	TiB Bytesize = 1024 * GiB
+	PiB Bytesize = 1024 * TiB
+	EiB Bytesize = 1024 * PiB
+)
+
+// Bytes returns the number of Bytes (B) in b
+func (b Bytesize) Bytes() float64 {
+	return float64(b)
+}
+
+// Kilobytes returns the number of Kilobytes (KB) in b
+func (b Bytesize) Kilobytes() float64 {
+	return float64(b / KB)
+}
+
+// Megabytes returns the number of Megabytes (MB) in b
+func (b Bytesize) Megabytes() float64 {
+	return float64(b / MB)
+}
+
+// Gigabytes returns the number of Gigabytes (GB) in b
+func (b Bytesize) Gigabytes() float64 {
+	return float64(b / GB)
+}
+
+// Terabytes returns the number of Terabytes (TB) in b
+func (b Bytesize) Terabytes() float64 {
+	return float64(b / TB)
+}
+
+// Petabytes returns the number of Petabytes (PB) in b
+func (b Bytesize) Petabytes() float64 {
+	return float64(b / PB)
+}
+
+// Exabytes returns the number of Exabytes (EB) in b
+func (b Bytesize) Exabytes() float64 {
+	return float64(b / EB)
+}
+
+// Kibibytes returns the number of Kibibytes (KiB) in b
+func (b Bytesize) Kibibytes() float64 {
+	return float64(b / KiB)
+}
+
+// Mebibytes returns the number of Mebibbytes (MiB) in b
+func (b Bytesize) Mebibytes() float64 {
+	return float64(b / MiB)
+}
+
+// Gibibytes returns the number of Gibibytes (GiB) in b
+func (b Bytesize) Gibibytes() float64 {
+	return float64(b / GiB)
+}
+
+// Tebibytes returns the number of Tebibytes (TiB) in b
+func (b Bytesize) Tebibytes() float64 {
+	return float64(b / TiB)
+}
+
+// Pebibytes returns the number of Pebibytes (PiB) in b
+func (b Bytesize) Pebibytes() float64 {
+	return float64(b / PiB)
+}
+
+// Exbibytes returns the number of Exbibytes (EiB) in b
+func (b Bytesize) Exbibytes() float64 {
+	return float64(b / EiB)
+}
+
+// Format returns a textual representation of the Bytesize value formatted
+// according to layout, which defines the format by specifying an abbreviation.
+// Abbreviations are not case-sensitive.
+//
+// Valid abbreviations are as follows:
+//	B (Bytesizes)
+//	KB (Kilobytes)
+//	MB (Megabytes)
+//	GB (Gigabytes)
+//	TB (Terabytes)
+//	PB (Petabytes)
+//	EB (Exabytes)
+//	KiB (Kibibytes)
+//	MiB (Mebibytes)
+//	GiB (Gibibytes)
+//	TiB (Tebibtyes)
+//	PiB (Pebibytes)
+//	EiB (Exbibyte)
+func (b Bytesize) Format(layout string) string {
+	switch strings.ToLower(layout) {
+	case "b":
+		return fmt.Sprintf("%gB", b.Bytes())
+	case "kb":
+		return fmt.Sprintf("%gKB", b.Kilobytes())
+	case "mb":
+		return fmt.Sprintf("%gMB", b.Megabytes())
+	case "gb":
+		return fmt.Sprintf("%gGB", b.Gigabytes())
+	case "tb":
+		return fmt.Sprintf("%gTB", b.Terabytes())
+	case "pb":
+		return fmt.Sprintf("%gPB", b.Petabytes())
+	case "eb":
+		return fmt.Sprintf("%gEB", b.Exabytes())
+	case "kib":
+		return fmt.Sprintf("%gKiB", b.Kibibytes())
+	case "mib":
+		return fmt.Sprintf("%gMiB", b.Mebibytes())
+	case "gib":
+		return fmt.Sprintf("%gGiB", b.Gibibytes())
+	case "tib":
+		return fmt.Sprintf("%gTiB", b.Tebibytes())
+	case "pib":
+		return fmt.Sprintf("%gPiB", b.Pebibytes())
+	case "eib":
+		return fmt.Sprintf("%gEiB", b.Exbibytes())
+	default:
+		return fmt.Sprintf("%%!%s(byte=%g)", layout, b)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -241,6 +241,12 @@
 			"revisionTime": "2017-06-26T21:20:07Z"
 		},
 		{
+			"checksumSHA1": "SZaMeoqPH0b36UUwpmgnW7VqDB0=",
+			"path": "github.com/zpatrick/go-bytesize",
+			"revision": "40b68ac70b6ad801369c8de9df588ffa5b9b4275",
+			"revisionTime": "2017-02-14T18:21:26Z"
+		},
+		{
 			"checksumSHA1": "QeZ2xsLZBpItk0uZtsh1T7NofPg=",
 			"path": "github.com/zpatrick/go-cache",
 			"revision": "07dbf58cb418d923cced58e7201d742c6adb969d",


### PR DESCRIPTION
**What does this pull request do?**
If Auth0 returns a 429 response ("too many requests"), the Authenticator will keep retrying after an increasing period of time until the authentication request is able to get through and the credentials are found to be valid or invalid.


**How should this be tested?**
Spin up an API locally (you'll get more output with `export DIMSIO_DEBUG=true`), then hammer it with bad requests.

```
# spins up two backgrounded processes that hammer an api running on localhost:9090

(for x in {0..49}; do echo "Request A-$x:"; curl -u bad0:bad0 localhost:9090/repository/tlake; echo; done) & P1=$! ; (for x in {0..49}; do echo "Request B-$x:"; curl -u bad0:bad1 localhost:9090/repository/tlake; echo; done) & P2=$!; wait $P1 $P2
```


**Checklist**
- [x] Unit tests
- [ ] Smoke tests
- ~System tests~
- ~Documentation~


closes #47