### PR TITLE
Empty user pass fix

### DIFF
--- a/auth/auth0_manager.go
+++ b/auth/auth0_manager.go
@@ -87,7 +87,8 @@ func (a *Auth0Manager) Authenticate(username, password string) (bool, error) {
 }
 
 func (a *Auth0Manager) authenticate(username, password string) (bool, error) {
-	log.Printf("[DEBUG] Attempting to authenticate user %s through Auth0", username)
+	log.Printf("[DEBUG] Attempting to authenticate user '%s' through Auth0", username)
+
 	req := oauthReq{
 		ClientID:   a.clientID,
 		Connection: a.connection,

--- a/auth/composite_authenticator.go
+++ b/auth/composite_authenticator.go
@@ -1,7 +1,13 @@
 package auth
 
+import "fmt"
+
 func NewCompositeAuthenticator(authenticators ...Authenticator) AuthenticatorFunc {
 	return AuthenticatorFunc(func(user, pass string) (bool, error) {
+		if user == "" || pass == "" {
+			return false, fmt.Errorf("username and/or password is empty")
+		}
+
 		for _, authenticator := range authenticators {
 			isValid, err := authenticator.Authenticate(user, pass)
 			if err != nil {

--- a/auth/composite_authenticator_test.go
+++ b/auth/composite_authenticator_test.go
@@ -12,9 +12,7 @@ func newTestAuthenticator(isValid bool, err error) AuthenticatorFunc {
 
 func TestEmptyUserPass(t *testing.T) {
 	target := NewCompositeAuthenticator()
-	_, err := target.Authenticate("", "")
-
-	if err == nil {
+	if _, err := target.Authenticate("", ""); err == nil {
 		t.Fatalf("Error expected when authenticating with no user and pass")
 	}
 }

--- a/auth/composite_authenticator_test.go
+++ b/auth/composite_authenticator_test.go
@@ -10,6 +10,15 @@ func newTestAuthenticator(isValid bool, err error) AuthenticatorFunc {
 	})
 }
 
+func TestEmptyUserPass(t *testing.T) {
+	target := NewCompositeAuthenticator()
+	_, err := target.Authenticate("", "")
+
+	if err == nil {
+		t.Fatalf("Error expected when authenticating with no user and pass")
+	}
+}
+
 func TestCompositeAuthenticator(t *testing.T) {
 	cases := []struct {
 		Name           string


### PR DESCRIPTION
**What does this PR do**
Composite authenticator validates for an empty username or password passed in via basic auth. So an empty username or password fails before attempting to authenticate with any authenticators.

fixes #53 